### PR TITLE
EMPT-88: XSS in appointment request notes

### DIFF
--- a/omod/src/main/webapp/fragments/patientAppointmentRequests.gsp
+++ b/omod/src/main/webapp/fragments/patientAppointmentRequests.gsp
@@ -84,8 +84,9 @@
         <div class="dialog-header">
             <h3>${ ui.message("appointmentschedulingui.scheduleAppointment.appointmentRequestNotes") }</h3>
         </div>
-        <div class="dialog-content" ng-bind-html="notesDialogContent">
-
+        
+        <div class="dialog-content" ng-bind="notesDialogContent">
+            
         </div>
         <button class="button confirm right" ng-click="closeNotesDialog()"> ${ ui.message("uicommons.close") }</button>
     </div>


### PR DESCRIPTION
EMPT-88. This XSS vulnerability appears in the dialog box that shows when viewing an existing appointment requests note.

Currently, appointment requests notes are put onto the page using `ng-bind-html` instead of `ng-bind`. I swapped it to `ng-bind` so it is just put into the dialog as raw text instead of HTML.

cc @isears 