### PR TITLE
RA-1875: EMPT134 Handled Root UI Framework Error in manageAppointmentSchedulingType page

### DIFF
--- a/omod/src/main/java/org/openmrs/module/appointmentschedulingui/page/controller/AppointmentTypePageController.java
+++ b/omod/src/main/java/org/openmrs/module/appointmentschedulingui/page/controller/AppointmentTypePageController.java
@@ -23,6 +23,9 @@ public class AppointmentTypePageController {
 
         if(appointmentTypeId!=null){
             appointmentType = appointmentService.getAppointmentType(appointmentTypeId);
+            if(appointmentType == null){
+                log.warn("Invalid Appointment Type ID.");
+            }
         }
 
         model.addAttribute("appointmentType", appointmentType);


### PR DESCRIPTION
### Description of What I Changed

Added warning log when appointment type ID provided in URL is invalid.

### Issue I Worked On
Steps to reproduce the vulnerability:

1. Launch the OpenMRS application.
2. Login with username "Admin" and password "Admin123" with location as Inpatient Ward.
3. Click Appointment Scheduling in the homepage, and then choose Manage Service type.
4. On the page, try to edit the one with the name as “Dermatology” by clicking the pencil icon under the Actions column.
5. Edit the appointmentTypeId parameter of the url. For example, the url for Dermatology is `http://localhost:8080/openmrs/appointmentschedulingui/appointmentType.page?appointmentTypeId=1&`. Modify it with appointmentTypeId=1000. So the url becomes `http://localhost:8080/openmrs/appointmentschedulingui/appointmentType.page?appointmentTypeId=1000&`.
6. Press enter. 

Output: Root UI Framework Error is displayed without any specific cause stated, even in logs.

### Link to ticket

[RA-1875](https://issues.openmrs.org/browse/RA-1875)

@isears