### PR TITLE
RA-1875: EMPT 22 in DailyScheduledAppointmentsPageController.java

### DIFF
--- a/omod/src/main/java/org/openmrs/module/appointmentschedulingui/page/controller/DailyScheduledAppointmentsPageController.java
+++ b/omod/src/main/java/org/openmrs/module/appointmentschedulingui/page/controller/DailyScheduledAppointmentsPageController.java
@@ -2,6 +2,7 @@ package org.openmrs.module.appointmentschedulingui.page.controller;
 
 import org.openmrs.Location;
 import org.openmrs.LocationTag;
+import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.module.appointmentschedulingui.AppointmentSchedulingUIProperties;
 import org.openmrs.module.appui.UiSessionContext;
 import org.openmrs.module.emrapi.EmrApiConstants;
@@ -13,7 +14,13 @@ public class DailyScheduledAppointmentsPageController {
     public void get(PageModel pageModel,
                     @SpringBean("appointmentSchedulingUIProperties")AppointmentSchedulingUIProperties properties,
                     UiSessionContext uiSessionContext){
-
+		
+		uiSessionContext.requireAuthentication();
+		System.out.println(uiSessionContext.getCurrentUser().getPrivileges());
+		if (!uiSessionContext.getCurrentUser().hasPrivilege("App: appointmentschedulingui.viewAppointments")
+		        && (!uiSessionContext.getCurrentUser().isSuperUser())) {
+			throw new APIAuthenticationException();
+		}
        Location location = uiSessionContext.getSessionLocation();
        LocationTag supportsAppointmentsTag =  properties.getSupportsAppointmentsTag();
        pageModel.addAttribute("supportsAppointmentsTagUuid",

--- a/omod/src/main/java/org/openmrs/module/appointmentschedulingui/page/controller/DailyScheduledAppointmentsPageController.java
+++ b/omod/src/main/java/org/openmrs/module/appointmentschedulingui/page/controller/DailyScheduledAppointmentsPageController.java
@@ -16,7 +16,6 @@ public class DailyScheduledAppointmentsPageController {
                     UiSessionContext uiSessionContext){
 		
 		uiSessionContext.requireAuthentication();
-		System.out.println(uiSessionContext.getCurrentUser().getPrivileges());
 		if (!uiSessionContext.getCurrentUser().hasPrivilege("App: appointmentschedulingui.viewAppointments")
 		        && (!uiSessionContext.getCurrentUser().isSuperUser())) {
 			throw new APIAuthenticationException();

--- a/omod/src/main/java/org/openmrs/module/appointmentschedulingui/page/controller/DailyScheduledAppointmentsPageController.java
+++ b/omod/src/main/java/org/openmrs/module/appointmentschedulingui/page/controller/DailyScheduledAppointmentsPageController.java
@@ -18,7 +18,7 @@ public class DailyScheduledAppointmentsPageController {
 		uiSessionContext.requireAuthentication();
 		if (!uiSessionContext.getCurrentUser().hasPrivilege("App: appointmentschedulingui.viewAppointments")
 		        && (!uiSessionContext.getCurrentUser().isSuperUser())) {
-			throw new APIAuthenticationException();
+			throw new APIAuthenticationException("Access to daily scheduled appointments page denied due to insufficient privileges");
 		}
        Location location = uiSessionContext.getSessionLocation();
        LocationTag supportsAppointmentsTag =  properties.getSupportsAppointmentsTag();


### PR DESCRIPTION
# Description of what I changed
I check to see if the user doesn't have the privilege and isn't a superuser. If both of these are true then I throw an APIAuthenticationException

# Issue I worked on
an issue where users without the App: appointmentschedulingui.viewAppointments privilege are still able to access the daily scheduled appointments page at /openmrs/appointmentschedulingui/dailyScheduledAppointments.page

# It can be reproduced following
-Launch OpenMRS application using the URL: http://localhost:8080/openmrs
-Provide following info and click login​Username​ as ​admin​ Password​ ​ as ​admin123 Location as ​Inpatient
-Click on “System Administration”.
-Click on “Manage Accounts”.
-Click on the “Add New Account” button.
-In the “Family Name” field, type in “Megan”.
-In the “Given Name” field, type in “Jones”.
-Select Female as Gender.
-Check the “Add User Account?” checkbox.
-In “Username” field type in “mjones”.
-Select “Full” for “Privilege Level”.
-In “Password” and “Confirm Password” fields type in “Megan123*”.
-Uncheck the “Force Password Change” checkbox.
-Click the “Save” button.
-Go to “Appointment Scheduling”.
-Go to “Daily Appointments”.
-Copy the URL.
-Log out of the system.
-In the “Username” field type in “mjones”.
-In the “Password” field type in “Megan123*”.
-Select “Registration Desk” as the Location for this Session.
-Click on the “Login” button to log into the system.
-Go to the URL you copied in 17.

# Link to ticket
https://issues.openmrs.org/browse/RA-1875

@isears