### PR TITLE
Remove dependency on global bower installation

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,8 +42,6 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Install Bower
-        run: npm install -g bower
       - name: Install dependencies
         run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode --show-version --file pom.xml
       - name: Build with Maven

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ omod/.classpath
 omod/.settings/
 omod/target/
 
+# Frontend build directories
+omod/src/main/webapp/resources/scripts/node
 omod/src/main/compass/sass-external/
 omod/src/main/webapp/resources/scripts/bower_components/
 
@@ -27,3 +29,4 @@ omod/src/main/webapp/resources/scripts/bower_components/
 # Rubygems build directories #
 omod/.rubygems
 omod/.rubygems-provided
+

--- a/README.md
+++ b/README.md
@@ -5,15 +5,10 @@ Appointment Scheduling UI Module
 
 New UI for appointment scheduling module based on UI/App framework
 
-**Prerequisites:** Before building the mdoule, please make sure that you have setup the following on your machine:  
-* Git
-* npm
-* Bower
+### Troubleshooting
 
-Helpful hints:
-
-If the jasmine tests are failing, it may be because your bower components directory is stale.
-
-To fix this, delete `omod/serc/main/webapp/reosurces/scripts/bower_components.openmrs-uicommons` directory and then rerun a maven clean install.
+If the jasmine tests are failing, it may be because your bower components directory is stale. To fix this, delete
+the `omod/serc/main/webapp/reosurces/scripts/bower_components.openmrs-uicommons` directory
+and then rerun a maven clean install.
 
 

--- a/omod/package-lock.json
+++ b/omod/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "mirebalais.apppointmentschedulingui",
+  "version": "0.0.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mirebalais.apppointmentschedulingui",
+      "version": "0.0.1",
+      "license": "Apache v2.0",
+      "devDependencies": {}
+    }
+  }
+}

--- a/omod/package.json
+++ b/omod/package.json
@@ -2,9 +2,7 @@
   "name": "mirebalais.apppointmentschedulingui",
   "version": "0.0.1",
   "description": "Mirebalais - Apppointment Scheduling Ui",
-  "dependencies": {},
-  "devDependencies": {
-  },
+  "devDependencies": {},
   "repository": {
     "type": "git",
     "url": "git://github.com/PIH/openmrs-module-appointmentschedulingui.git"

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -349,27 +349,33 @@
 			  </executions>
 			</plugin>
 
-
-			<plugin>
-	   			<groupId>org.codehaus.mojo</groupId>
-			   	<artifactId>exec-maven-plugin</artifactId>
-			   	<executions>
-		     		<execution>
-	     				<phase>generate-sources</phase>
-		     			<goals>
-		      				<goal>exec</goal>
-		     			</goals>
-		     		</execution>
-			   	</executions>
-   				<configuration>
-		     		<executable>bower</executable>
-		     		<arguments>
-						<argument>install</argument>
-                        <argument>--allow-root</argument>
-		     		</arguments>
-		     		<workingDirectory>${basedir}/src/main/webapp/resources/scripts/</workingDirectory>
-		   		</configuration>
-		 	</plugin>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>1.11.3</version>
+                <configuration>
+                    <nodeVersion>v14.17.0</nodeVersion>
+                    <npmVersion>7.6.2</npmVersion>
+                    <workingDirectory>${basedir}/src/main/webapp/resources/scripts/</workingDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>install node and npm</id>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>bower install</id>
+                        <goals>
+                            <goal>npx</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>bower install --allow-root</arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
 		</plugins>
 	</build>


### PR DESCRIPTION
Just a slight improvement to build tooling. No more prerequisites.

I don't know what that `package.json` file is about; AFAICT it doesn't do anything and could be deleted. But maybe there is some magic with omods, I dunno.