### PR TITLE
Changing rubygems link to work with later Maven versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
         </repository>
         <repository>
             <id>rubygems-releases</id>
-            <url>http://rubygems-proxy.torquebox.org/releases</url>
+            <url>https://rubygems-proxy.torquebox.org/releases/url</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Changed the RubyGems link from http://rubygems-proxy.torquebox.org/releases to https://rubygems-proxy.torquebox.org/releases/url, so it is compatible with recent Maven versions. 