### PR TITLE
Move appointmentScheduling version to 1.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <uicommonsVersion>2.1</uicommonsVersion>
         <coreappsVersion>1.11.1</coreappsVersion>
         <webservicesRestVersion>2.6</webservicesRestVersion>
-        <appointmentschedulingVersion>1.15.0-SNAPSHOT</appointmentschedulingVersion>
+        <appointmentschedulingVersion>1.16.0</appointmentschedulingVersion>
         <testutilsVersion>1.5</testutilsVersion>
         <!-- Need to phase this out. -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
When I try to release appointmentSchedulingUi, it complains that this dependency is still on the snapshot version. Indeed, it's on an old snapshot version. Hopefully this should allow appointmentSchedulingUi to be released.