### PR TITLE
RATEST-219: AddPatientAppointment & BookRequestAppointment tests fail  master build plan on Sundays and Saturdays

### DIFF
--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -147,7 +147,7 @@
    
    <globalProperty>
         <property>appointmentschedulingui.includeWeekends</property>
-        <defaultValue>false</defaultValue>
+        <defaultValue>true</defaultValue>
         <description>
             Defines whether the calendar should include weekends 
         </description>

--- a/omod/src/main/webapp/resources/scripts/controllers/scheduleProvidersController.js
+++ b/omod/src/main/webapp/resources/scripts/controllers/scheduleProvidersController.js
@@ -98,7 +98,7 @@ angular.module('appointmentscheduling.scheduleProviders')
             // configure the calendar
             calendar:{
                 ignoreTimezone: false,  // does this parameter do anything?
-                weekends: includeWeekends,
+                weekends: true,
                 header:{
                     left: 'month basicWeek basicDay',
                     center: 'title',

--- a/omod/src/main/webapp/resources/scripts/controllers/scheduleProvidersController.js
+++ b/omod/src/main/webapp/resources/scripts/controllers/scheduleProvidersController.js
@@ -98,7 +98,7 @@ angular.module('appointmentscheduling.scheduleProviders')
             // configure the calendar
             calendar:{
                 ignoreTimezone: false,  // does this parameter do anything?
-                weekends: true,
+                weekends: includeWeekends,
                 header:{
                     left: 'month basicWeek basicDay',
                     center: 'title',


### PR DESCRIPTION
Ticket [ID](https://issues.openmrs.org/browse/RATEST-219)

Description ->  The calendar in "Manage Appointment Blocks" page doesn't have Saturday & Sunday and besides failing the [UI](https://ci.openmrs.org/browse/REFAPP-UI) master build plan on those two specific days for the tests. As well in some countries those days are considered to be working days. More details is attached on the ticket description !